### PR TITLE
[Feature] #12 - 인풋 컴포넌트를 구현한다

### DIFF
--- a/src/storybook/stories/design-system/components/index.ts
+++ b/src/storybook/stories/design-system/components/index.ts
@@ -1,2 +1,3 @@
 export { default as Button } from './Button/Button';
 export { default as TopNav } from './topnav/TopNav';
+export { default as InputField } from './Button/Button';

--- a/src/storybook/stories/design-system/components/inputfield/InputField.stories.tsx
+++ b/src/storybook/stories/design-system/components/inputfield/InputField.stories.tsx
@@ -1,0 +1,86 @@
+// components/InputField/InputField.stories.tsx
+import React, { useState } from 'react';
+import { storiesOf } from '@storybook/react-native';
+import { View, ScrollView, Text } from 'react-native';
+import { ThemeProvider } from '@emotion/react';
+
+import InputField from './InputField';
+import theme from '@styles/theme';
+
+const withTheme = (Story: React.ComponentType) => (
+  <ThemeProvider theme={theme}>
+    <View
+      style={{
+        flex: 1,
+        padding: 20,
+        backgroundColor: theme.colors.Neutral.WHITE,
+      }}
+    >
+      <Story />
+    </View>
+  </ThemeProvider>
+);
+
+type ControlledProps = Omit<
+  React.ComponentProps<typeof InputField>,
+  'value' | 'onChangeText'
+> & {
+  initialValue?: string;
+};
+
+const ControlledInput: React.FC<ControlledProps> = ({
+  initialValue = '',
+  ...props
+}) => {
+  const [val, setVal] = useState(initialValue);
+  return <InputField {...props} value={val} onChangeText={setVal} />;
+};
+
+const AllVariants = () => (
+  <ScrollView>
+    <Text
+      style={[
+        theme.typography.Head1_1,
+        { marginBottom: 12, color: theme.colors.Neutral.N70 },
+      ]}
+    >
+      Default Inputs
+    </Text>
+
+    <ControlledInput
+      label="이메일"
+      inputProps={{
+        placeholder: 'example@email.com',
+        keyboardType: 'email-address',
+        autoCapitalize: 'none',
+      }}
+      helperText="로그인 시 사용하는 이메일을 입력하세요."
+    />
+
+    <View style={{ height: 20 }} />
+
+    <Text
+      style={[
+        theme.typography.Head1_1,
+        { marginBottom: 12, color: theme.colors.Neutral.N70 },
+      ]}
+    >
+      Secure Inputs
+    </Text>
+
+    <ControlledInput
+      label="비밀번호"
+      variant="secure"
+      inputProps={{
+        placeholder: '비밀번호를 입력하세요',
+        autoCapitalize: 'none',
+      }}
+      helperText="영문, 숫자, 특수문자를 포함해야 합니다."
+    />
+  </ScrollView>
+);
+
+// ✅ 스토리 등록
+storiesOf('Components/InputField', module)
+  .addDecorator(withTheme)
+  .add('All Variants', () => <AllVariants />);

--- a/src/storybook/stories/design-system/components/inputfield/InputField.styles.ts
+++ b/src/storybook/stories/design-system/components/inputfield/InputField.styles.ts
@@ -1,0 +1,57 @@
+import styled from '@emotion/native';
+import { Feather } from '@expo/vector-icons';
+
+export const Wrapper = styled.View(({ theme }) => ({
+  flex: 1,
+  flexDirection: 'column',
+  gap: theme.space.XS,
+}));
+
+export const Label = styled.Text(({ theme }) => ({
+  ...theme.typography.Body1_2,
+  color: theme.colors.Neutral.N70,
+}));
+
+export const InputWrapper = styled.View(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: theme.space.XS,
+}));
+
+export const InputContainer = styled.View(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  borderBottomWidth: 2,
+  borderBottomColor: theme.colors.Neutral.N30,
+  paddingHorizontal: theme.space.XS,
+  paddingVertical: theme.space.S,
+}));
+
+export const Input = styled.TextInput<{ masked?: boolean }>(
+  ({ theme, masked }) => ({
+    ...theme.typography.Body1_2,
+    color: theme.colors.Neutral.N70,
+    flex: 1,
+    letterSpacing: masked ? 4 : 0,
+    '::placeholder': {
+      color: theme.colors.Neutral.N30,
+    },
+  })
+);
+
+export const EyeButton = styled.TouchableOpacity({
+  padding: 2.25,
+});
+
+export const EyeIcon = styled(Feather)(({ theme }) => ({
+  color: theme.colors.Neutral.N70,
+  width: 19.5,
+  height: 19.5,
+  fontSize: 19.5,
+}));
+
+export const HelperText = styled.Text(({ theme }) => ({
+  ...theme.typography.Body2_2,
+  color: theme.colors.Warning.R30,
+}));

--- a/src/storybook/stories/design-system/components/inputfield/InputField.tsx
+++ b/src/storybook/stories/design-system/components/inputfield/InputField.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+import * as S from './InputField.styles';
+import { TextInputProps } from 'react-native';
+import type { Variant } from './InputField.types';
+import { useTheme } from '@emotion/react';
+
+type InputFieldProps = {
+  label?: string;
+  value: string;
+  onChangeText: (t: string) => void;
+  variant?: Variant;
+  inputProps?: Omit<
+    TextInputProps,
+    'secureTextEntry' | 'value' | 'onChangeText'
+  >;
+  helperText?: string;
+  disabled?: boolean;
+};
+
+export default function InputField({
+  label,
+  value,
+  onChangeText,
+  variant = 'default',
+  inputProps,
+  helperText,
+  disabled,
+}: InputFieldProps) {
+  const theme = useTheme();
+  const [hidden, setHidden] = useState(variant === 'secure');
+  const hasValue = !!value && value.length > 0;
+  const [focused, setFocused] = useState(false);
+  const isSecureVariant = variant === 'secure';
+  const placeholderColor = focused ? 'transparent' : theme.colors.Neutral.N30;
+  return (
+    <S.Wrapper>
+      {!!label && <S.Label>{label}</S.Label>}
+      <S.InputWrapper>
+        <S.InputContainer>
+          <S.Input
+            masked={isSecureVariant && hidden && hasValue}
+            editable={!disabled}
+            value={value}
+            onChangeText={onChangeText}
+            secureTextEntry={isSecureVariant && hidden}
+            placeholderTextColor={placeholderColor}
+            onFocus={() => setFocused(true)}
+            onBlur={() => setFocused(false)}
+            {...inputProps}
+          />
+
+          {isSecureVariant && hasValue && (
+            <S.EyeButton onPress={() => setHidden((prev) => !prev)}>
+              <S.EyeIcon name={hidden ? 'eye' : 'eye-off'} />
+            </S.EyeButton>
+          )}
+        </S.InputContainer>
+
+        {/* 헬퍼 텍스트 */}
+        {helperText && <S.HelperText>{helperText}</S.HelperText>}
+      </S.InputWrapper>
+    </S.Wrapper>
+  );
+}

--- a/src/storybook/stories/design-system/components/inputfield/InputField.types.ts
+++ b/src/storybook/stories/design-system/components/inputfield/InputField.types.ts
@@ -1,0 +1,1 @@
+export type Variant = 'default' | 'secure';

--- a/src/storybook/stories/index.ts
+++ b/src/storybook/stories/index.ts
@@ -1,1 +1,2 @@
 import './design-system/components/Button/Button.stories';
+import './design-system/components/inputfield/InputField.stories';


### PR DESCRIPTION
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성-->

- InputField(입력 필드) 디자인 시스템 컴포넌트 개발 및 스토리북 예시 추가
- 일반 입력/비밀번호 입력(secure) 등 Variant 지원
- 헬퍼 텍스트, 라벨, disabled 등 다양한 프로퍼티 대응
- theme 기반 스타일 적용

## 📸 Screenshot

<!-- 작업한 화면의 스크린 샷 -->

|                 이미지1                 |
| :-------------------------------------: |
| <img src="https://github.com/user-attachments/assets/d8989724-b5d1-42f9-89f7-f21c81a82ac8" width="300" /> |


## 📍 PR Point

<!-- 자랑하고 싶은 부분!  -->

- 실무에서 바로 쓸 수 있는 input UI/UX 구조에 집중
- secure 입력 UX 개선(eye 아이콘, 마스킹 등)
- theme·타입 시스템 적용으로 유지보수성 향상
- 스토리북을 통한 다양한 prop 동작 테스트

## 📢 Notices

<!--공용으로 사용하는 부분에 대한 설명-->

- 디자인 시스템 내 기본 Input 컴포넌트로 활용 가능
- 추후 “에러/포커스 시 색변경” 등 확장 예정
- TextInput의 native props는 inputProps로 전달 가능

## 💭 Related Issues

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

#12
